### PR TITLE
Multifile Upload Support, NumPy rand out of range fix, and small renaming changes.

### DIFF
--- a/src/pixel_generator/__init__.py
+++ b/src/pixel_generator/__init__.py
@@ -19,7 +19,6 @@ class PixelGenerator:
   
                 img_array[y, x] = (new_r, new_g, new_b, a)
 
-
         return Image.fromarray(img_array.astype('uint8'))
 
     def get_avg_colour(self, img):
@@ -94,7 +93,7 @@ class PixelGenerator:
 
     def get_colour_palette(self, img_array, num_colours=6):
         pixels = img_array.reshape((-1,4))
-        rand_int = np.random.randint(0, 2**32)
+        rand_int = np.random.randint(0, 2**31)
         kmeans = KMeans(n_clusters=num_colours, random_state=rand_int)
         kmeans.fit(pixels)
         colours = kmeans.cluster_centers_.astype(int)
@@ -124,27 +123,3 @@ class PixelGenerator:
 
         return Image.fromarray(quantized.astype('uint8'))
     
-    def extract_colours(self, img):
-        img = img.convert('RGB')
-
-        img_array = np.array(img)
-        colours = img_array.reshape(-1, 3)
-
-        unique_colours = []
-        seen = set()
-
-        for colour in colours:
-            colour_tuple = tuple(colour)
-            if colour_tuple not in seen:
-                seen.add(colour_tuple)
-                unique_colours.append(colour)
-
-        unique_colours = np.array(unique_colours)
-
-        colour_line = np.zeros((1, len(unique_colours), 3), dtype=np.uint8)
-        colour_line[0, :, :] = unique_colours
-
-        colour_line_img = Image.fromarray(colour_line)
-        colour_line_img = colour_line_img.resize((len(unique_colours), 1), Image.Resampling.NEAREST)
-
-        return colour_line_img

--- a/src/pixel_generator/__init__.py
+++ b/src/pixel_generator/__init__.py
@@ -123,3 +123,27 @@ class PixelGenerator:
 
         return Image.fromarray(quantized.astype('uint8'))
     
+    def extract_colours(self, img):
+        img = img.convert('RGB')
+
+        img_array = np.array(img)
+        colours = img_array.reshape(-1, 3)
+
+        unique_colours = []
+        seen = set()
+
+        for colour in colours:
+            colour_tuple = tuple(colour)
+            if colour_tuple not in seen:
+                seen.add(colour_tuple)
+                unique_colours.append(colour)
+
+        unique_colours = np.array(unique_colours)
+
+        colour_line = np.zeros((1, len(unique_colours), 3), dtype=np.uint8)
+        colour_line[0, :, :] = unique_colours
+
+        colour_line_img = Image.fromarray(colour_line)
+        colour_line_img = colour_line_img.resize((len(unique_colours), 1), Image.Resampling.NEAREST)
+
+        return colour_line_img

--- a/src/procedural_textures/__init__.py
+++ b/src/procedural_textures/__init__.py
@@ -32,7 +32,7 @@ class ProceduralTextures:
         scale = 1
         width = img_size[0]
         height = img_size[1]
-        rand_int = np.random.randint(0, 2**32)
+        rand_int = np.random.randint(0, 2**31)
         opensimplex.seed(rand_int)
         result = np.zeros((width, height))
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -95,8 +95,6 @@
                         <p>Factor:</p>
                         <input type="number" id="paletteFactor" name="paletteFactor" step="0.1" value="1.0" min="0.0", max="1.0">
                     </li> 
-                    <h2>Get Colour palette</h2>
-                    <button id="getColourPalette" class="pure-button pure-button-primary">GetColours</button>
                 </div>
                 <div id="wang-sidebar">
                     <h2>Generate Wang tileset</h2>
@@ -156,7 +154,7 @@
                         <input type="number" id="noiseOctaves" name="noiseOctaves" value="2" min="1" max="100">
                     </li>
                     <li class="pure-menu-item">
-                        <p>Persistance:</p>
+                        <p>Persistence:</p>
                         <input type="number" id="noisePersistance" name="noisePersistance" step="0.1" value="0.5" max="100">
                     </li>
                     <li class="pure-menu-item">
@@ -237,15 +235,19 @@
         <div class="content">
             <div class="pure-g">
                 <div class="pure-u-1-2">
-                    <input type="file" id="imageUpload" accept="image/*" class="pure-button">
+                    <form id="imageInputForm">
+                        <input type="file" id="imageUpload" accept="image/*" class="pure-button" multiple>
+                    </form>
+                    <button id="imageClear" class="pure-button">Clear</button>
                 </div>
                 <div class="pure-u-1-2">
                     <button id="setOutputAsInput" class="pure-button pure-button-primary">Use output as input</button>
                 </div>
             </div>
             <div class="pure-g">
+                <div class="previewContainer" id="inputPreviewContainer"></div>
                 <div class="pure-u-1-2 container"  id="imageContainer">
-                
+
                 </div>
                 <div class="pure-u-1-2">
                     <div id="loader"></div>

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -101,6 +101,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     document.getElementById('imageClear').addEventListener('click', function(event) {
         fileIndex = 0;
+        inputPreviewContainer.innerHTML = '';
         imageInputForm.reset();
         updateSelectedFile(null);
     });
@@ -127,7 +128,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
     document.getElementById("setOutputAsInput").addEventListener('click', function() {
         imageClear.click()
-        inputPreviewContainer.innerHTML = '';
         updateSelectedFile(outputFile);
     });
 

--- a/src/static/styles/styles.css
+++ b/src/static/styles/styles.css
@@ -37,10 +37,13 @@
   max-height: 80%;
 }
 
+.active-selection {
+  border: #333 solid 3px ;
+}
+
 .container img {
   object-fit: contain;
   object-position: center;
-  image-rendering: pixelated;
   width: 100%;
   height: 100%;
 }
@@ -52,6 +55,10 @@
 
 .colour-input {
   width: 100%;
+}
+
+.hidden {
+  display: none;
 }
 
 #loader {
@@ -67,6 +74,7 @@
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
 
 /* Sidebar content */
 #pixel-sidebar {


### PR DESCRIPTION
HTML page now allows multifile uploads and moves each image into a preview bar on the left. From there, users can select the image to set that as the new working image. A 'Clear' button was added to hide current upload information.

When running, I would get errors from the NumPy randint calls, stating `high is out for bounds for int32`. Fixed this by changing the `high` parameter to 2^31 (signed int max).

Small renaming changes to function calls in js to follow the same naming convention. "Persistance" in webpage corrected to "Persistence".